### PR TITLE
🔀 :: 이메일 인증 회원가입 로직에 적용

### DIFF
--- a/src/main/java/com/juicycool/backend/domain/auth/exception/NotVerificationMailException.java
+++ b/src/main/java/com/juicycool/backend/domain/auth/exception/NotVerificationMailException.java
@@ -1,0 +1,10 @@
+package com.juicycool.backend.domain.auth.exception;
+
+import com.juicycool.backend.global.exception.ErrorCode;
+import com.juicycool.backend.global.exception.GlobalException;
+
+public class NotVerificationMailException extends GlobalException {
+    public NotVerificationMailException() {
+        super(ErrorCode.NOT_VERIFICATION_MAIL);
+    }
+}

--- a/src/main/java/com/juicycool/backend/domain/auth/presentation/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/juicycool/backend/domain/auth/presentation/dto/request/SignUpRequestDto.java
@@ -1,13 +1,15 @@
 package com.juicycool.backend.domain.auth.presentation.dto.request;
 
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class SignUpRequestDto {
-
+    @Pattern(regexp = ".+@.+", message = "이메일 형식에 맞지 않습니다.")
     private String email;
     private String name;
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*[0-9])|(?=.*[A-Za-z])(?=.*[^A-Za-z0-9])|(?=.*[0-9])(?=.*[^A-Za-z0-9]).{8,}$", message = "비밀번호 형식이 올바르지 않습니다.")
     private String password;
 }

--- a/src/main/java/com/juicycool/backend/domain/auth/service/impl/SignUpServiceImpl.java
+++ b/src/main/java/com/juicycool/backend/domain/auth/service/impl/SignUpServiceImpl.java
@@ -1,8 +1,11 @@
 package com.juicycool.backend.domain.auth.service.impl;
 
 import com.juicycool.backend.domain.auth.exception.DuplicateEmailException;
+import com.juicycool.backend.domain.auth.exception.NotVerificationMailException;
 import com.juicycool.backend.domain.auth.presentation.dto.request.SignUpRequestDto;
 import com.juicycool.backend.domain.auth.service.SignUpService;
+import com.juicycool.backend.domain.email.MailAuthEntity;
+import com.juicycool.backend.domain.email.repository.MailAuthRepository;
 import com.juicycool.backend.domain.user.User;
 import com.juicycool.backend.domain.user.repository.UserRepository;
 import com.juicycool.backend.global.annotation.TransactionService;
@@ -15,10 +18,19 @@ public class SignUpServiceImpl implements SignUpService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final MailAuthRepository mailAuthRepository;
 
     public void execute(SignUpRequestDto dto) {
-        if (userRepository.existsByEmail(dto.getEmail()))
+        if (userRepository.existsByEmail(dto.getEmail())) {
+            mailAuthRepository.deleteById(dto.getEmail());
             throw new DuplicateEmailException();
+        }
+
+        MailAuthEntity mailAuth = mailAuthRepository.findById(dto.getEmail())
+                .orElseThrow(NotVerificationMailException::new);
+
+        if (!mailAuth.getAuthentication())
+            throw new NotVerificationMailException();
 
         User user = User.builder()
                 .email(dto.getEmail())
@@ -26,6 +38,8 @@ public class SignUpServiceImpl implements SignUpService {
                 .password(passwordEncoder.encode(dto.getPassword()))
                 .points(100000)
                 .build();
+
+        mailAuthRepository.delete(mailAuth);
 
         userRepository.save(user);
 

--- a/src/main/java/com/juicycool/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/juicycool/backend/global/exception/ErrorCode.java
@@ -18,7 +18,8 @@ public enum ErrorCode {
 
     // mail
     ALREADY_AUTHENTICATED_MAIL(400, "이미 인증된 메일입니다."),
-    EXPIRED_AUTH_CODE(401, "이미 만료된 인증코드입니다.");
+    EXPIRED_AUTH_CODE(401, "이미 만료된 인증코드입니다."),
+    NOT_VERIFICATION_MAIL(401, "인증된 메일이 아닙니다.");
 
     private final int status;
     private final String message;


### PR DESCRIPTION
## 💡 배경 및 개요

이메일 인증을 만들고 나서 회원가입에 적용해야되서 적용하였습니다.

Resolves: #31 

## 📃 작업내용

레디스에 저장되어있는 mailAuth를 확인후 회원가입 로직을 정상적으로 진행되게 하였습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타