### PR TITLE
🔀 :: 해당 커뮤니티의 게시물 전체 불러오기

### DIFF
--- a/src/main/java/com/juicycool/backend/domain/board/presentation/BoardController.java
+++ b/src/main/java/com/juicycool/backend/domain/board/presentation/BoardController.java
@@ -2,13 +2,16 @@ package com.juicycool.backend.domain.board.presentation;
 
 import com.juicycool.backend.domain.board.presentation.dto.request.WriteBoardRequestDto;
 import com.juicycool.backend.domain.board.presentation.dto.response.GetBoardInfoResponseDto;
+import com.juicycool.backend.domain.board.presentation.dto.response.GetBoardListResponseDto;
 import com.juicycool.backend.domain.board.service.GetBoardInfoService;
+import com.juicycool.backend.domain.board.service.GetBoardListService;
 import com.juicycool.backend.domain.board.service.WriteBoardService;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,6 +20,7 @@ public class BoardController {
 
     private final WriteBoardService writeBoardService;
     private final GetBoardInfoService getBoardInfoService;
+    private final GetBoardListService getBoardListService;
 
     @PostMapping("/{community_id}")
     public ResponseEntity<Void> writeBoard(
@@ -30,6 +34,12 @@ public class BoardController {
     @GetMapping("/{board_id}")
     public ResponseEntity<GetBoardInfoResponseDto> getBoardInfo(@PathVariable("board_id") Long boardId) {
         GetBoardInfoResponseDto response = getBoardInfoService.execute(boardId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/list/{community_id}")
+    public ResponseEntity<List<GetBoardListResponseDto>> getBoardList(@PathVariable("community_id") Long communityId) {
+        List<GetBoardListResponseDto> response = getBoardListService.execute(communityId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/juicycool/backend/domain/board/presentation/dto/response/GetBoardListResponseDto.java
+++ b/src/main/java/com/juicycool/backend/domain/board/presentation/dto/response/GetBoardListResponseDto.java
@@ -1,0 +1,16 @@
+package com.juicycool.backend.domain.board.presentation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder
+public class GetBoardListResponseDto {
+    private Long id;
+    private String title;
+    private String content;
+    private String created_at;
+    private Integer likes;
+    private Integer comment_num;
+}

--- a/src/main/java/com/juicycool/backend/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/juicycool/backend/domain/board/repository/BoardRepository.java
@@ -1,7 +1,11 @@
 package com.juicycool.backend.domain.board.repository;
 
 import com.juicycool.backend.domain.board.Board;
+import com.juicycool.backend.domain.community.Community;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BoardRepository extends JpaRepository<Board, Long> {
+    List<Board> findByCommunity(Community community);
 }

--- a/src/main/java/com/juicycool/backend/domain/board/service/GetBoardListService.java
+++ b/src/main/java/com/juicycool/backend/domain/board/service/GetBoardListService.java
@@ -1,0 +1,9 @@
+package com.juicycool.backend.domain.board.service;
+
+import com.juicycool.backend.domain.board.presentation.dto.response.GetBoardListResponseDto;
+
+import java.util.List;
+
+public interface GetBoardListService {
+    List<GetBoardListResponseDto> execute(Long communityId);
+}

--- a/src/main/java/com/juicycool/backend/domain/board/service/impl/GetBoardListServiceImpl.java
+++ b/src/main/java/com/juicycool/backend/domain/board/service/impl/GetBoardListServiceImpl.java
@@ -1,0 +1,41 @@
+package com.juicycool.backend.domain.board.service.impl;
+
+import com.juicycool.backend.domain.board.presentation.dto.response.GetBoardListResponseDto;
+import com.juicycool.backend.domain.board.repository.BoardRepository;
+import com.juicycool.backend.domain.board.service.GetBoardListService;
+import com.juicycool.backend.domain.community.Community;
+import com.juicycool.backend.domain.community.exception.NotFoundCommunityException;
+import com.juicycool.backend.domain.community.repository.CommunityRepository;
+import com.juicycool.backend.global.annotation.ReadOnlyTransactionService;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ReadOnlyTransactionService
+@RequiredArgsConstructor
+public class GetBoardListServiceImpl implements GetBoardListService {
+
+    private final BoardRepository boardRepository;
+    private final CommunityRepository communityRepository;
+
+    public List<GetBoardListResponseDto> execute(Long communityId) {
+        Community community = communityRepository.findById(communityId)
+                .orElseThrow(NotFoundCommunityException::new);
+
+        return boardRepository.findByCommunity(community).stream()
+                .map(board -> GetBoardListResponseDto.builder()
+                        .id(board.getId())
+                        .title(board.getTitle())
+                        .content(board.getContent())
+                        .created_at(String.valueOf(board.getCreateAt()))
+                        .likes(board.getLikes())
+                        .comment_num(board.getComment_num())
+                        .build())
+                .collect(Collectors.toList());
+
+
+
+
+    }
+}

--- a/src/main/java/com/juicycool/backend/domain/community/repository/CommunityRepository.java
+++ b/src/main/java/com/juicycool/backend/domain/community/repository/CommunityRepository.java
@@ -4,4 +4,5 @@ import com.juicycool.backend.domain.community.Community;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommunityRepository extends JpaRepository<Community, Long> {
+    boolean existsById(Long id);
 }

--- a/src/main/java/com/juicycool/backend/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/juicycool/backend/global/security/config/SecurityConfig.java
@@ -64,6 +64,7 @@ public class SecurityConfig {
                                 // board
                                 .requestMatchers(HttpMethod.POST, "/api/v1/board/{community_id}").authenticated()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/board/{board_id}").authenticated()
+                                .requestMatchers(HttpMethod.GET, "/api/v1/board/list/{community_id}").authenticated()
 
                                 .anyRequest().denyAll()
 


### PR DESCRIPTION
## 💡 배경 및 개요

커뮤니티의 게시물을 모두 불러오는 api를 추가하였습니다

Resolves: #47 

## 📃 작업내용

해당 커뮤니티의 id를 path로 입력하면 커뮤니티의 게시물을 모두 불러오는 것을 만들었습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타