### PR TITLE
🔀 :: 커뮤니티 게시판 삭제 api

### DIFF
--- a/src/main/java/com/juicycool/backend/domain/board/presentation/BoardController.java
+++ b/src/main/java/com/juicycool/backend/domain/board/presentation/BoardController.java
@@ -4,10 +4,7 @@ import com.juicycool.backend.domain.board.presentation.dto.request.UpdateBoardRe
 import com.juicycool.backend.domain.board.presentation.dto.request.WriteBoardRequestDto;
 import com.juicycool.backend.domain.board.presentation.dto.response.GetBoardInfoResponseDto;
 import com.juicycool.backend.domain.board.presentation.dto.response.GetBoardListResponseDto;
-import com.juicycool.backend.domain.board.service.GetBoardInfoService;
-import com.juicycool.backend.domain.board.service.GetBoardListService;
-import com.juicycool.backend.domain.board.service.UpdateBoardService;
-import com.juicycool.backend.domain.board.service.WriteBoardService;
+import com.juicycool.backend.domain.board.service.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +21,7 @@ public class BoardController {
     private final GetBoardInfoService getBoardInfoService;
     private final GetBoardListService getBoardListService;
     private final UpdateBoardService updateBoardService;
+    private final DeleteBoardService deleteBoardService;
 
     @PostMapping("/{community_id}")
     public ResponseEntity<Void> writeBoard(
@@ -52,6 +50,12 @@ public class BoardController {
         @RequestBody UpdateBoardRequestDto dto
     ) {
         updateBoardService.execute(boardId, dto);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{board_id}")
+    public ResponseEntity<Void> deleteBoard(@PathVariable("board_id") Long boardId) {
+        deleteBoardService.execute(boardId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/juicycool/backend/domain/board/service/DeleteBoardService.java
+++ b/src/main/java/com/juicycool/backend/domain/board/service/DeleteBoardService.java
@@ -1,0 +1,5 @@
+package com.juicycool.backend.domain.board.service;
+
+public interface DeleteBoardService {
+    void execute(Long boardId);
+}

--- a/src/main/java/com/juicycool/backend/domain/board/service/impl/DeleteBoardServiceImpl.java
+++ b/src/main/java/com/juicycool/backend/domain/board/service/impl/DeleteBoardServiceImpl.java
@@ -1,0 +1,39 @@
+package com.juicycool.backend.domain.board.service.impl;
+
+import com.juicycool.backend.domain.board.Board;
+import com.juicycool.backend.domain.board.exception.NotFoundBoardException;
+import com.juicycool.backend.domain.board.exception.NotMatchUserException;
+import com.juicycool.backend.domain.board.repository.BoardRepository;
+import com.juicycool.backend.domain.board.service.DeleteBoardService;
+import com.juicycool.backend.domain.comment.repository.CommentRepository;
+import com.juicycool.backend.domain.like.repository.LikeRepository;
+import com.juicycool.backend.domain.user.User;
+import com.juicycool.backend.domain.user.util.UserUtil;
+import com.juicycool.backend.global.annotation.TransactionService;
+import lombok.RequiredArgsConstructor;
+
+@TransactionService
+@RequiredArgsConstructor
+public class DeleteBoardServiceImpl implements DeleteBoardService {
+
+    private final BoardRepository boardRepository;
+    private final CommentRepository commentRepository;
+    private final LikeRepository likeRepository;
+    private final UserUtil userUtil;
+
+    public void execute(Long boardId) {
+        User user = userUtil.getCurrentUser();
+
+        Board findBoard = boardRepository.findById(boardId)
+                .orElseThrow(NotFoundBoardException::new);
+
+        if (user != findBoard.getUser())
+            throw new NotMatchUserException();
+
+
+        commentRepository.deleteByBoard(findBoard);
+        likeRepository.deleteByBoard(findBoard);
+        boardRepository.delete(findBoard);
+
+    }
+}

--- a/src/main/java/com/juicycool/backend/domain/comment/Comment.java
+++ b/src/main/java/com/juicycool/backend/domain/comment/Comment.java
@@ -1,5 +1,6 @@
 package com.juicycool.backend.domain.comment;
 
+import com.juicycool.backend.domain.board.Board;
 import com.juicycool.backend.domain.community.Community;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -22,7 +23,7 @@ public class Comment {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "community_id")
-    private Community community;
+    @JoinColumn(name = "board_id")
+    private Board board;
 
 }

--- a/src/main/java/com/juicycool/backend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/juicycool/backend/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package com.juicycool.backend.domain.comment.repository;
+
+import com.juicycool.backend.domain.board.Board;
+import com.juicycool.backend.domain.comment.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    void deleteByBoard(Board board);
+}

--- a/src/main/java/com/juicycool/backend/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/juicycool/backend/domain/like/repository/LikeRepository.java
@@ -1,0 +1,9 @@
+package com.juicycool.backend.domain.like.repository;
+
+import com.juicycool.backend.domain.board.Board;
+import com.juicycool.backend.domain.like.Likes;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Likes, Long> {
+    void deleteByBoard(Board board);
+}

--- a/src/main/java/com/juicycool/backend/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/juicycool/backend/global/security/config/SecurityConfig.java
@@ -66,6 +66,7 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.GET, "/api/v1/board/{board_id}").authenticated()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/board/list/{community_id}").authenticated()
                                 .requestMatchers(HttpMethod.PATCH, "/api/v1/board/{board_id}").authenticated()
+                                .requestMatchers(HttpMethod.DELETE, "/api/v1/board/{board_id}").authenticated()
 
                                 .anyRequest().denyAll()
 


### PR DESCRIPTION
## 💡 배경 및 개요

커뮤니티 게시판을 삭제하는 api를 추가하였습니다

Resolves: #51 

## 📃 작업내용

커뮤니티 게시판을 삭제하는 api를 추가하고 Comment가 Community를 단뱡향 매핑하고 있던 것을 Board를 하게 변경하였습니다

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타