### PR TITLE
🔀 :: 주식 매수 예약

### DIFF
--- a/src/main/java/com/juicycool/backend/domain/reservation/Reservation.java
+++ b/src/main/java/com/juicycool/backend/domain/reservation/Reservation.java
@@ -37,5 +37,4 @@ public class Reservation {
     public void plusStockNum(Long num) {
         this.stockNum += num;
     }
-
 }

--- a/src/main/java/com/juicycool/backend/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/juicycool/backend/domain/reservation/repository/ReservationRepository.java
@@ -1,6 +1,7 @@
 package com.juicycool.backend.domain.reservation.repository;
 
 import com.juicycool.backend.domain.reservation.Reservation;
+import com.juicycool.backend.domain.reservation.Status;
 import com.juicycool.backend.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,6 +10,7 @@ import java.util.Optional;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
     List<Reservation> findByUser(User user);
-    Optional<Reservation> findByUserAndStockCode(User user, Integer stockCode);
+//    Optional<Reservation> findByUserAndStockCode(User user, Integer stockCode);
     Boolean existsByUserAndStockCode(User user, Integer stockCode);
+    Optional<Reservation> findByUserAndStockCodeAndStatus(User user, Integer stockCode, Status status);
 }

--- a/src/main/java/com/juicycool/backend/domain/stock/presentation/StockController.java
+++ b/src/main/java/com/juicycool/backend/domain/stock/presentation/StockController.java
@@ -1,12 +1,11 @@
 package com.juicycool.backend.domain.stock.presentation;
 
+import com.juicycool.backend.domain.stock.presentation.dto.request.BuyReservRequestDto;
 import com.juicycool.backend.domain.stock.presentation.dto.request.BuyStockRequestDto;
+import com.juicycool.backend.domain.stock.presentation.dto.request.SellReservRequestDto;
 import com.juicycool.backend.domain.stock.presentation.dto.request.SellStockRequestDto;
 import com.juicycool.backend.domain.stock.presentation.dto.response.GetListStockResponseDto;
-import com.juicycool.backend.domain.stock.service.BuyStockService;
-import com.juicycool.backend.domain.stock.service.GetListStockService;
-import com.juicycool.backend.domain.stock.service.SellReservationStockService;
-import com.juicycool.backend.domain.stock.service.SellStockService;
+import com.juicycool.backend.domain.stock.service.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +22,7 @@ public class StockController {
     private final SellStockService sellStockService;
     private final GetListStockService getListStockService;
     private final SellReservationStockService sellReservationStockService;
+    private final BuyReservationStockService buyReservationStockService;
 
     @PostMapping("/{stock_id}")
     public ResponseEntity<Void> buyStock(
@@ -51,9 +51,18 @@ public class StockController {
     @PostMapping("/sell/{stock_id}")
     public ResponseEntity<Void> sellReservationStock(
         @PathVariable("stock_id") Long stockId,
-        @RequestBody SellStockRequestDto dto
+        @RequestBody SellReservRequestDto dto
     ) {
         sellReservationStockService.execute(stockId, dto);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/buy/{stock_id}")
+    public ResponseEntity<Void> buyReservationStock(
+        @PathVariable("stock_id") Long stockId,
+        @RequestBody BuyReservRequestDto dto
+    ) {
+        buyReservationStockService.execute(stockId, dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/com/juicycool/backend/domain/stock/presentation/dto/request/BuyReservRequestDto.java
+++ b/src/main/java/com/juicycool/backend/domain/stock/presentation/dto/request/BuyReservRequestDto.java
@@ -1,0 +1,11 @@
+package com.juicycool.backend.domain.stock.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class BuyReservRequestDto {
+    private Long num;
+    private Long goal_price;
+}

--- a/src/main/java/com/juicycool/backend/domain/stock/presentation/dto/request/SellReservRequestDto.java
+++ b/src/main/java/com/juicycool/backend/domain/stock/presentation/dto/request/SellReservRequestDto.java
@@ -1,0 +1,11 @@
+package com.juicycool.backend.domain.stock.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SellReservRequestDto {
+    private Long num;
+    private Long goal_price;
+}

--- a/src/main/java/com/juicycool/backend/domain/stock/presentation/dto/request/SellStockRequestDto.java
+++ b/src/main/java/com/juicycool/backend/domain/stock/presentation/dto/request/SellStockRequestDto.java
@@ -7,5 +7,4 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SellStockRequestDto {
     private Long num;
-    private Long goal_price;
 }

--- a/src/main/java/com/juicycool/backend/domain/stock/service/BuyReservationStockService.java
+++ b/src/main/java/com/juicycool/backend/domain/stock/service/BuyReservationStockService.java
@@ -1,0 +1,7 @@
+package com.juicycool.backend.domain.stock.service;
+
+import com.juicycool.backend.domain.stock.presentation.dto.request.BuyReservRequestDto;
+
+public interface BuyReservationStockService {
+    void execute(Long stockId, BuyReservRequestDto dto);
+}

--- a/src/main/java/com/juicycool/backend/domain/stock/service/SellReservationStockService.java
+++ b/src/main/java/com/juicycool/backend/domain/stock/service/SellReservationStockService.java
@@ -1,7 +1,7 @@
 package com.juicycool.backend.domain.stock.service;
 
-import com.juicycool.backend.domain.stock.presentation.dto.request.SellStockRequestDto;
+import com.juicycool.backend.domain.stock.presentation.dto.request.SellReservRequestDto;
 
 public interface SellReservationStockService {
-    void execute(Long stockId, SellStockRequestDto dto);
+    void execute(Long stockId, SellReservRequestDto dto);
 }

--- a/src/main/java/com/juicycool/backend/domain/stock/service/impl/BuyReservationStockServiceImpl.java
+++ b/src/main/java/com/juicycool/backend/domain/stock/service/impl/BuyReservationStockServiceImpl.java
@@ -1,0 +1,56 @@
+package com.juicycool.backend.domain.stock.service.impl;
+
+import com.juicycool.backend.domain.reservation.Reservation;
+import com.juicycool.backend.domain.reservation.Status;
+import com.juicycool.backend.domain.reservation.repository.ReservationRepository;
+import com.juicycool.backend.domain.stock.Stock;
+import com.juicycool.backend.domain.stock.exception.NotFoundStockException;
+import com.juicycool.backend.domain.stock.exception.PointLowerThanPresentPriceException;
+import com.juicycool.backend.domain.stock.presentation.dto.request.BuyReservRequestDto;
+import com.juicycool.backend.domain.stock.repository.StockRepository;
+import com.juicycool.backend.domain.stock.service.BuyReservationStockService;
+import com.juicycool.backend.domain.user.User;
+import com.juicycool.backend.domain.user.util.UserUtil;
+import com.juicycool.backend.global.annotation.TransactionService;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@TransactionService
+@RequiredArgsConstructor
+public class BuyReservationStockServiceImpl implements BuyReservationStockService {
+
+    private final StockRepository stockRepository;
+    private final UserUtil userUtil;
+    private final ReservationRepository reservationRepository;
+
+    public void execute(Long stockId, BuyReservRequestDto dto) {
+        User user = userUtil.getCurrentUser();
+
+        Stock stock = stockRepository.findById(stockId)
+                .orElseThrow(NotFoundStockException::new);
+
+        if (dto.getGoal_price() * dto.getNum() > user.getPoints())
+            throw new PointLowerThanPresentPriceException();
+
+        saveReservation(user, dto, stock);
+    }
+
+    private void saveReservation(User user, BuyReservRequestDto dto, Stock stock) {
+        Reservation reservation = reservationRepository.findByUserAndStockCodeAndStatus(user, stock.getCode(), Status.BUY)
+                .orElse(Reservation.builder()
+                        .stockCode(stock.getCode())
+                        .stockName(stock.getName())
+                        .reservationPrice(dto.getGoal_price())
+                        .status(Status.BUY)
+                        .user(user)
+                        .stockNum(0L)
+                        .build());
+
+        reservation.plusStockNum(dto.getNum());
+
+        reservationRepository.save(reservation);
+
+
+    }
+}

--- a/src/main/java/com/juicycool/backend/domain/stock/service/impl/SellReservationStockServiceImpl.java
+++ b/src/main/java/com/juicycool/backend/domain/stock/service/impl/SellReservationStockServiceImpl.java
@@ -9,6 +9,7 @@ import com.juicycool.backend.domain.stock.exception.NotFoundOwnedStockException;
 import com.juicycool.backend.domain.stock.exception.NotFoundReservationException;
 import com.juicycool.backend.domain.stock.exception.NotFoundStockException;
 import com.juicycool.backend.domain.stock.exception.PointLowerThanPresentPriceException;
+import com.juicycool.backend.domain.stock.presentation.dto.request.SellReservRequestDto;
 import com.juicycool.backend.domain.stock.presentation.dto.request.SellStockRequestDto;
 import com.juicycool.backend.domain.stock.repository.OwnedStocksRepository;
 import com.juicycool.backend.domain.stock.repository.StockRepository;
@@ -27,7 +28,7 @@ public class SellReservationStockServiceImpl implements SellReservationStockServ
     private final OwnedStocksRepository ownedStocksRepository;
     private final UserUtil userUtil;
 
-    public void execute(Long stockId, SellStockRequestDto dto) {
+    public void execute(Long stockId, SellReservRequestDto dto) {
         User user = userUtil.getCurrentUser();
 
         Stock stock = stockRepository.findById(stockId)
@@ -42,12 +43,12 @@ public class SellReservationStockServiceImpl implements SellReservationStockServ
         saveReservation(stock, dto, user);
     }
 
-    private void saveReservation(Stock stock, SellStockRequestDto dto, User user) {
+    private void saveReservation(Stock stock, SellReservRequestDto dto, User user) {
         if (reservationRepository.existsByUserAndStockCode(user, stock.getCode())) {
-            Reservation reservation = reservationRepository.findByUserAndStockCode(user, stock.getCode())
-                    .orElseThrow(NotFoundReservationException::new);
-
-            reservation.plusStockNum(dto.getNum());
+//            Reservation reservation = reservationRepository.findByUserAndStockCode(user, stock.getCode())
+//                    .orElseThrow(NotFoundReservationException::new);
+//
+//            reservation.plusStockNum(dto.getNum());
         } else {
             Reservation reservation = Reservation.builder()
                     .stockCode(stock.getCode())

--- a/src/main/java/com/juicycool/backend/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/juicycool/backend/global/security/config/SecurityConfig.java
@@ -66,6 +66,7 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.DELETE, "/api/v1/stock/{stock_id}").authenticated()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/stock").authenticated()
                                 .requestMatchers(HttpMethod.POST, "/api/v1/stock/sell/{stock_id}").authenticated()
+                                .requestMatchers(HttpMethod.POST, "/api/v1/stock/buy/{stock_id}").authenticated()
 
                                 // board
                                 .requestMatchers(HttpMethod.POST, "/api/v1/board/{community_id}").authenticated()


### PR DESCRIPTION
## 💡 배경 및 개요

주식 매수 예약 api 추가

Resolves: #79 

## 📃 작업내용

주식 매수 예약 api를 추가하였고 매도 예약 api 로직 중 일부분을 주석처리하여 작동하지 않게 하였습니다.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타