### PR TITLE
🔀 :: 7시 55분에 모든 day 초기화

### DIFF
--- a/src/main/java/com/juicycool/backend/domain/day/scheduler/DayScheduler.java
+++ b/src/main/java/com/juicycool/backend/domain/day/scheduler/DayScheduler.java
@@ -1,5 +1,6 @@
 package com.juicycool.backend.domain.day.scheduler;
 
+import com.juicycool.backend.domain.day.service.ClearDayService;
 import com.juicycool.backend.domain.day.service.SaveDayService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component;
 public class DayScheduler {
 
     private final SaveDayService saveDayService;
+    private final ClearDayService clearDayService;
 
     @Scheduled(cron = "0 5-55/10 8-14 * * *", zone = "Asia/Seoul")
     @Scheduled(cron = "0 5,15,25,35 15 * * *", zone = "Asia/Seoul")
@@ -19,5 +21,12 @@ public class DayScheduler {
         log.info("--------------saveDay start--------------");
         saveDayService.saveDay();
         log.info("--------------saveDay end--------------");
+    }
+
+    @Scheduled(cron = "0 55 7 * * *", zone = "Asia/Seoul")
+    public void clearDay() {
+        log.info("--------------clearDay start--------------");
+        clearDayService.execute();
+        log.info("--------------clearDay end--------------");
     }
 }

--- a/src/main/java/com/juicycool/backend/domain/day/service/ClearDayService.java
+++ b/src/main/java/com/juicycool/backend/domain/day/service/ClearDayService.java
@@ -1,0 +1,23 @@
+package com.juicycool.backend.domain.day.service;
+
+import com.juicycool.backend.domain.day.Day;
+import com.juicycool.backend.domain.day.repository.DayRepository;
+import com.juicycool.backend.global.annotation.TransactionService;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@TransactionService
+@RequiredArgsConstructor
+public class ClearDayService {
+
+    private final DayRepository dayRepository;
+
+    public void execute() {
+        List<Day> days = dayRepository.findAll();
+
+        for (Day day : days) {
+            dayRepository.delete(day);
+        }
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 개요

다음 날의 장을 맞이하기 위해 장 열리기 5분전에 day를 초기화를 추가하였습니다

Resolves: #111 

## 📃 작업내용

장이 열리는 8시에 5분 전인 7시 55분이 day를 초기화하는 clearDayScheduler를 추가하였습니다

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타