### PR TITLE
🔀 :: 매도, 매수 후에 구매내역 기록

### DIFF
--- a/src/main/java/com/juicycool/backend/domain/stock/service/impl/BuyStockServiceImpl.java
+++ b/src/main/java/com/juicycool/backend/domain/stock/service/impl/BuyStockServiceImpl.java
@@ -1,5 +1,8 @@
 package com.juicycool.backend.domain.stock.service.impl;
 
+import com.juicycool.backend.domain.receipt.Receipt;
+import com.juicycool.backend.domain.receipt.repository.ReceiptRepository;
+import com.juicycool.backend.domain.reservation.Status;
 import com.juicycool.backend.domain.stock.OwnedStocks;
 import com.juicycool.backend.domain.stock.Stock;
 import com.juicycool.backend.domain.stock.exception.NotFoundStockException;
@@ -20,6 +23,7 @@ public class BuyStockServiceImpl implements BuyStockService {
     private final StockRepository stockRepository;
     private final OwnedStocksRepository ownedStocksRepository;
     private final UserUtil userUtil;
+    private final ReceiptRepository receiptRepository;
 
     public void execute(Long stockId, BuyStockRequestDto dto) {
         User user = userUtil.getCurrentUser();
@@ -34,6 +38,7 @@ public class BuyStockServiceImpl implements BuyStockService {
 
         saveOwnedStock(dto.getNum(), user, stock);
         user.deductPoints(allPoint);
+        saveReceipt(user, stock, allPoint);
     }
 
     private void saveOwnedStock(Long number, User user, Stock stock) {
@@ -47,5 +52,16 @@ public class BuyStockServiceImpl implements BuyStockService {
         ownedStock.plusStockNum(number);
 
         ownedStocksRepository.save(ownedStock);
+    }
+
+    private void saveReceipt(User user, Stock stock, Long buyPoints) {
+        Receipt receipt = Receipt.builder()
+                .price(buyPoints)
+                .status(Status.BUY)
+                .stockName(stock.getName())
+                .user(user)
+                .build();
+
+        receiptRepository.save(receipt);
     }
 }

--- a/src/main/java/com/juicycool/backend/domain/stock/service/impl/SellStockServiceImpl.java
+++ b/src/main/java/com/juicycool/backend/domain/stock/service/impl/SellStockServiceImpl.java
@@ -1,5 +1,8 @@
 package com.juicycool.backend.domain.stock.service.impl;
 
+import com.juicycool.backend.domain.receipt.Receipt;
+import com.juicycool.backend.domain.receipt.repository.ReceiptRepository;
+import com.juicycool.backend.domain.reservation.Status;
 import com.juicycool.backend.domain.stock.OwnedStocks;
 import com.juicycool.backend.domain.stock.Stock;
 import com.juicycool.backend.domain.stock.exception.InvalidSellingNumberException;
@@ -21,6 +24,7 @@ public class SellStockServiceImpl implements SellStockService {
     private final OwnedStocksRepository ownedStocksRepository;
     private final StockRepository stockRepository;
     private final UserUtil userUtil;
+    private final ReceiptRepository receiptRepository;
 
     public void execute(Long stockId, SellStockRequestDto dto) {
         User user = userUtil.getCurrentUser();
@@ -39,6 +43,20 @@ public class SellStockServiceImpl implements SellStockService {
             throw new InvalidSellingNumberException();
         }
 
-        user.addSellPoints(stock.getPresentPrice() * dto.getNum());
+        Long sellPoints = stock.getPresentPrice() * dto.getNum();
+
+        user.addSellPoints(sellPoints);
+        saveReceipt(user, stock, sellPoints);
+    }
+
+    private void saveReceipt(User user, Stock stock, Long buyPoints) {
+        Receipt receipt = Receipt.builder()
+                .price(buyPoints)
+                .status(Status.SELL)
+                .stockName(stock.getName())
+                .user(user)
+                .build();
+
+        receiptRepository.save(receipt);
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요

매도와 매수 이후에 구매내역에 기록을 남겨 기록을 볼 수 있게 추가하였습니다

Resolves: #117 

## 📃 작업내용

매도 api와 매수 api에 saveReceipt를 추가하였습니다

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타